### PR TITLE
Updated OpenUI to version 1.36.15.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>openui5</artifactId>
-    <version>1.36.14-SNAPSHOT</version>
+    <version>1.36.15-SNAPSHOT</version>
     <name>OpenUI5</name>
     <description>WebJar for OpenUI5</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.36.13</upstream.version>
+        <upstream.version>1.36.15</upstream.version>
         <upstream.url>https://openui5.hana.ondemand.com/downloads</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs />


### PR DESCRIPTION
Updated OpenUI to version 1.36.15.

Updates after this will begin tracking 1.38 instead of 1.36.